### PR TITLE
Fix Big5 questionnaire responsive layout and survey completion flow

### DIFF
--- a/tools/questionnaires/big5/index.html
+++ b/tools/questionnaires/big5/index.html
@@ -22,9 +22,13 @@
     <style>
         /* ── existing finished panel ── */
         #finished {
-            display:none;
+            display: none;
+            position: relative;
+            z-index: 100;
             padding: 20px;
             max-width: 700px;
+            width: 100%;
+            box-sizing: border-box;
             margin: 0 auto;
             box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
             border-radius: 10px;
@@ -32,7 +36,8 @@
             text-align: center;
         }
         #finished h3, p { margin:0px; padding:0px; }
-#finished #reset-survey { margin-left: 30%; }
+        #finished #reset-survey { display: block; margin: 8px auto 0; }
+        #chatgpt-prompt { width: 100%; box-sizing: border-box; }
 
         /* ═══════════════════════════════════════════════
            CHARACTER CARD STYLES
@@ -41,10 +46,13 @@
         /* ── wooden frame ── */
         .cc-frame {
             position: relative;
-            display: inline-block;
+            display: block;
             padding: 12px;
             border-radius: 8px;
             margin: 16px auto;
+            width: fit-content;
+            max-width: 100%;
+            box-sizing: border-box;
             background:
                 linear-gradient(170deg, #3b2816 0%, #2a1b0e 30%, #4a3220 55%, #2e1e12 80%, #3b2816 100%);
             box-shadow:
@@ -70,7 +78,7 @@
         .cc-parchment {
             position: relative;
             width: 340px;
-            max-width: 100%;
+            max-width: calc(100vw - 56px);
             padding: 24px 24px 20px;
             border-radius: 4px;
             background:
@@ -201,6 +209,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            flex-wrap: wrap;
             gap: 10px;
             margin-bottom: 12px;
         }
@@ -220,12 +229,15 @@
             background: #fdf6e0;
             color: #2e1e0f;
             width: 240px;
+            max-width: calc(100vw - 48px);
+            box-sizing: border-box;
         }
 
         /* ── download button ── */
         .cc-download-btn {
             display: block;
             margin: 16px auto 0;
+            max-width: calc(100vw - 48px);
             padding: 10px 28px;
             font-family: 'Cinzel', serif;
             font-weight: 700;
@@ -271,7 +283,7 @@
 <body>
     <div id="surveyElement"></div>
     <div id="finished">
-        {{character-card}}
+        <div id="cc-card-placeholder"></div>
 
         <div class="cc-prompt-section">
             <h4>Or use this prompt with an image generator</h4>

--- a/tools/questionnaires/big5/index.js
+++ b/tools/questionnaires/big5/index.js
@@ -149,17 +149,17 @@ function surveyComplete(survey)
     promptText = promptText.replace("{{n-score}}", describeBar(scores["N"]));
     chatGptTextarea.textContent = promptText;
 
-    // Build the finished panel HTML
-    var finishedDiv = document.getElementById("finished");
-    finishedDiv.style.display = "block";
-    document.getElementById("finished").remove();
+    // Inject the character card directly into the DOM placeholder
+    document.getElementById("cc-card-placeholder").innerHTML = renderCharacterCard(scores);
 
-    var html = finishedDiv.outerHTML;
-
-    // Inject the character card
-    html = html.replace("{{character-card}}", renderCharacterCard(scores));
-
-    survey.completedHtml = html;
+    // Use an empty completedHtml to suppress SurveyJS's default completion panel,
+    // then swap visibility so #finished (with its working event handlers) is shown.
+    survey.completedHtml = "";
+    setTimeout(function() {
+        document.getElementById("surveyElement").style.display = "none";
+        document.getElementById("finished").style.display = "block";
+        window.scrollTo(0, 0);
+    }, 50);
 }
 
 function describeBar(score) {


### PR DESCRIPTION
## Summary
Refactored the Big5 questionnaire completion flow to improve responsive design and fix layout issues. The changes address viewport constraints, button alignment, and the survey completion panel rendering mechanism.

## Key Changes
- **Responsive Layout Improvements**
  - Added `max-width: calc(100vw - 56px)` to character card parchment to prevent horizontal overflow
  - Applied `box-sizing: border-box` and max-width constraints to text inputs and buttons
  - Added `flex-wrap: wrap` to button containers for better mobile responsiveness
  - Made character card frame `display: block` with `width: fit-content` for proper centering

- **Finished Panel Styling**
  - Added `position: relative` and `z-index: 100` for proper stacking context
  - Changed reset button from left-aligned (`margin-left: 30%`) to centered (`display: block; margin: 8px auto 0`)
  - Added `width: 100%` and `box-sizing: border-box` for full-width responsiveness
  - Added width constraint to ChatGPT prompt textarea

- **Survey Completion Flow Refactoring**
  - Replaced HTML string manipulation approach with direct DOM injection
  - Changed from modifying `completedHtml` to using a placeholder div (`#cc-card-placeholder`)
  - Set `survey.completedHtml = ""` to suppress SurveyJS default completion panel
  - Used `setTimeout` to ensure proper DOM state before showing the finished panel
  - Added `window.scrollTo(0, 0)` to scroll to top on completion

## Implementation Details
The previous implementation attempted to manipulate the finished panel HTML as a string and inject it into SurveyJS's `completedHtml` property. This approach was fragile and caused layout issues. The new approach keeps the finished panel in the DOM at all times with a placeholder for dynamic content, then simply toggles visibility and injects the character card HTML directly when the survey completes. This provides better control over styling and event handlers while maintaining responsive behavior across all viewport sizes.

https://claude.ai/code/session_01FVG8cdBscpfm7ixfZcqs6r