### PR TITLE
Fix Big5 questionnaire download and completion flow

### DIFF
--- a/tools/questionnaires/big5/index.html
+++ b/tools/questionnaires/big5/index.html
@@ -20,6 +20,8 @@
     <link rel="stylesheet" href="../inter-font.css">
 
     <style>
+        body { min-height: 100vh; }
+
         /* ── existing finished panel ── */
         #finished {
             display: none;

--- a/tools/questionnaires/big5/index.js
+++ b/tools/questionnaires/big5/index.js
@@ -100,10 +100,17 @@ function downloadCard() {
         useCORS: true,
         backgroundColor: null
     }).then(function(canvas) {
-        var link = document.createElement("a");
-        link.download = "ocean-character-card.png";
-        link.href = canvas.toDataURL("image/png");
-        link.click();
+        var dataUrl = canvas.toDataURL("image/png");
+        // iOS Safari ignores link.download; open the image in a new tab so
+        // the user can long-press → Save Image.
+        if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+            window.open(dataUrl, "_blank");
+        } else {
+            var link = document.createElement("a");
+            link.download = "ocean-character-card.png";
+            link.href = dataUrl;
+            link.click();
+        }
     });
 }
 
@@ -141,25 +148,22 @@ function surveyComplete(survey)
 
     // Populate the image-generator prompt textarea
     var chatGptTextarea = document.getElementById("chatgpt-prompt");
-    var promptText = chatGptTextarea.textContent;
+    var promptText = chatGptTextarea.value;
     promptText = promptText.replace("{{o-score}}", describeBar(scores["O"]));
     promptText = promptText.replace("{{c-score}}", describeBar(scores["C"]));
     promptText = promptText.replace("{{e-score}}", describeBar(scores["E"]));
     promptText = promptText.replace("{{a-score}}", describeBar(scores["A"]));
     promptText = promptText.replace("{{n-score}}", describeBar(scores["N"]));
-    chatGptTextarea.textContent = promptText;
+    chatGptTextarea.value = promptText;
 
     // Inject the character card directly into the DOM placeholder
     document.getElementById("cc-card-placeholder").innerHTML = renderCharacterCard(scores);
 
-    // Use an empty completedHtml to suppress SurveyJS's default completion panel,
-    // then swap visibility so #finished (with its working event handlers) is shown.
-    survey.completedHtml = "";
-    setTimeout(function() {
-        document.getElementById("surveyElement").style.display = "none";
-        document.getElementById("finished").style.display = "block";
-        window.scrollTo(0, 0);
-    }, 50);
+    // survey.showCompletedPage = false (set at init) stops SurveyJS navigating to
+    // its completion page, so we can swap visibility immediately with no timeout.
+    document.getElementById("surveyElement").style.display = "none";
+    document.getElementById("finished").style.display = "block";
+    window.scrollTo(0, 0);
 }
 
 function describeBar(score) {
@@ -187,6 +191,7 @@ document.addEventListener("DOMContentLoaded", async function() {
     survey.progressBarShowPageNumbers =  true;
     survey.progressBarShowPageTitles =  true;
     survey.focusFirstQuestionAutomatic = true;
+    survey.showCompletedPage = false;
 
     survey.onComplete.add(surveyComplete);
     survey.onValueChanged.add(survey => saveSurveyData(survey, STORAGE_ITEM_KEY));


### PR DESCRIPTION
## Summary
This PR fixes several issues in the Big5 questionnaire tool related to image downloading on iOS devices and the survey completion flow.

## Key Changes
- **iOS-compatible image download**: Modified `downloadCard()` to detect iOS devices and open the generated character card image in a new tab instead of attempting a direct download, since iOS Safari ignores the `link.download` attribute. Users can now long-press to save the image.
- **Fixed textarea value handling**: Changed from using `.textContent` to `.value` when reading and writing the ChatGPT prompt textarea, ensuring proper form field manipulation.
- **Improved completion page handling**: Replaced the timeout-based approach with a cleaner implementation using `survey.showCompletedPage = false` at initialization, eliminating the need for a 50ms delay and making the transition to the finished panel immediate and more reliable.
- **Minor styling**: Added `min-height: 100vh` to the body to ensure proper viewport coverage.

## Implementation Details
- The iOS detection uses a standard user agent check for iPad, iPhone, and iPod devices
- The completion flow now relies on SurveyJS's built-in `showCompletedPage` property instead of manipulating `completedHtml` and using setTimeout, resulting in cleaner and more maintainable code

https://claude.ai/code/session_01QxXnvg7GeLy4FKjkbk24AZ