### PR TITLE
Fix OCEAN final page not displaying on iPhone (iOS Safari layout bug)

### DIFF
--- a/tools/questionnaires/big5/index.html
+++ b/tools/questionnaires/big5/index.html
@@ -52,6 +52,7 @@
             padding: 12px;
             border-radius: 8px;
             margin: 16px auto;
+            width: -webkit-fit-content;
             width: fit-content;
             max-width: 100%;
             box-sizing: border-box;
@@ -80,7 +81,7 @@
         .cc-parchment {
             position: relative;
             width: 340px;
-            max-width: calc(100vw - 56px);
+            max-width: 100%;
             padding: 24px 24px 20px;
             border-radius: 4px;
             background:
@@ -231,7 +232,7 @@
             background: #fdf6e0;
             color: #2e1e0f;
             width: 240px;
-            max-width: calc(100vw - 48px);
+            max-width: 100%;
             box-sizing: border-box;
         }
 
@@ -239,7 +240,7 @@
         .cc-download-btn {
             display: block;
             margin: 16px auto 0;
-            max-width: calc(100vw - 48px);
+            max-width: 100%;
             padding: 10px 28px;
             font-family: 'Cinzel', serif;
             font-weight: 700;
@@ -312,7 +313,7 @@ proportionally scaled. Do not swap any colours.</textarea>
             </p>
         </div>
 
-        <button id="reset-survey" onclick="resetSurvey()">Reset survey</button>
+        <button id="reset-survey" onclick="resetSurvey(STORAGE_ITEM_KEY)">Reset survey</button>
     </div>
 
     <script src="../common.js"></script>

--- a/tools/questionnaires/big5/index.js
+++ b/tools/questionnaires/big5/index.js
@@ -163,6 +163,14 @@ function surveyComplete(survey)
     // its completion page, so we can swap visibility immediately with no timeout.
     document.getElementById("surveyElement").style.display = "none";
     document.getElementById("finished").style.display = "block";
+
+    // SurveyJS may have set overflow:hidden / height:100% on body/html for its
+    // full-page layout. Reset those so the results panel is scrollable on iOS.
+    document.body.style.overflow = '';
+    document.body.style.height = '';
+    document.documentElement.style.overflow = '';
+    document.documentElement.style.height = '';
+
     window.scrollTo(0, 0);
 }
 


### PR DESCRIPTION
- Fix parchment/button/input max-width from calc(100vw - Npx) to 100%
  so widths are relative to parent container, not the viewport. On 393px
  screens (iPhone 16/17) the parchment overflowed the frame by ~8px,
  causing page-level horizontal scroll that broke iOS Safari's layout.
- Add -webkit-fit-content fallback for cc-frame width on older Safari.
- Reset body/html overflow and height after survey completes so iOS
  can scroll the results panel (SurveyJS may leave overflow:hidden set).
- Fix resetSurvey() button call to pass STORAGE_ITEM_KEY so saved
  survey data is actually cleared on reset.

https://claude.ai/code/session_01KhUL4yyE7iqFCBwdn4X5Pz